### PR TITLE
.macro implementation

### DIFF
--- a/src/main/frontend/index.html
+++ b/src/main/frontend/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Venus@ICS v0.1.4</title>
+  <title>Venus@ICS v0.2.0</title>
   <link rel="stylesheet" type="text/css" href="css/venus.css">
   <!--<link rel="stylesheet" type="text/css" href="css/bulma.css">-->
   <!--<link rel="stylesheet" type="text/css" href="css/codemirror.css">-->
@@ -27,12 +27,13 @@
           <dd>- .data: Added .string type</dd>
           <dd>- li: Fixed an issue when using Hex Values for Immediate Field</dd>
           <dd>- Added Load and Download possibilities</dd>
+          <dd>- Added support for the .macro directive</dd>
           <dd>- More to come... </dd>
         </dl>
       </div>
     </section>
     <footer class="modal-card-foot">
-      Version: 0.1.4
+      Version: 0.2.0
     </footer>
   </div>
 </div>

--- a/src/main/frontend/index.html
+++ b/src/main/frontend/index.html
@@ -55,7 +55,7 @@
   <div style="padding-left: 0rem;" class="column is-one-quarter tabs is-boxed is-centerd">
     <ul>
       <li id="venus-version"><a style="cursor: not-allowed; text-decoration:none; pointer-events: none; color:#0084BB; font-weight: bold" href="blablabla">v</a></li>
-      <li><button class="js-modal-trigger" data-target="modal-js-example" style="padding-left: 0rem; color: #0084BB; font-weight: bold; font-size:18px; background: none!important; border: none; padding: 0!important; " onMouseOver="this.style.textDecoration='underline'" onMouseLeave="this.style.textDecoration='none'">0.1.4</button></li>
+      <li><button class="js-modal-trigger" data-target="modal-js-example" style="padding-left: 0rem; color: #0084BB; font-weight: bold; font-size:18px; background: none!important; border: none; padding: 0!important; " onMouseOver="this.style.textDecoration='underline'" onMouseLeave="this.style.textDecoration='none'">0.2.0</button></li>
 
     </ul>
   </div>

--- a/src/main/kotlin/venus/assembler/Assembler.kt
+++ b/src/main/kotlin/venus/assembler/Assembler.kt
@@ -74,7 +74,7 @@ internal class AssemblerMacroPass(private val text: String) {
         var currentLineNumber = 1
         for (line in text.split('\n')) {
             try {
-                val (labels, args) = Lexer.lexLine(line)
+                val (_, args) = Lexer.lexLine(line)
                 if (args.size == 0) { // skip blank lines
                     currentLineNumber++
                     outLines.add("")
@@ -105,7 +105,7 @@ internal class AssemblerMacroPass(private val text: String) {
                     currentMacro.instructions.add(line)
 
                     /** Mark wrong arguments */
-                    val (labels, tokens) = Lexer.lexLine(line)
+                    val (_, tokens) = Lexer.lexLine(line)
                     for (token in tokens) {
                         if (token[0] == '\\' && !currentMacro.args.contains(token.drop(1))) {
                             throw AssemblerError("Macro argument " + token + " invalid")
@@ -139,7 +139,7 @@ internal class AssemblerMacroPass(private val text: String) {
         while (index < outLines.size && outLines.size > 0) {
             try {
                 val line = outLines[index]
-                val (labels, args) = Lexer.lexLine(line)
+                val (_, args) = Lexer.lexLine(line)
                 if (args.size == 0) { // skip blank lines
                     index++
                     continue
@@ -155,7 +155,7 @@ internal class AssemblerMacroPass(private val text: String) {
                     // store index to later return to this place to expand nested macros
                     val storeIndex = index
                     for (instruction in macro!!.instructions) {
-                        val (labels, tokens) = Lexer.lexLine(instruction)
+                        val (_, tokens) = Lexer.lexLine(instruction)
 
                         /**
                          * A helper function that replaces arguments inside the macro body with the passed values
@@ -200,7 +200,8 @@ internal class AssemblerMacroPass(private val text: String) {
 }
 
 /**
- * Pass #2 of our two pass assembler.
+ * Pass #2
+ * of our two pass assembler.
  *
  * It parses labels, expands pseudo-instructions and follows assembler directives.
  * It populations [talInstructions], which is then used by [AssemblerPassThree] in order to actually assemble the code.

--- a/src/main/kotlin/venus/assembler/PseudoWriter.kt
+++ b/src/main/kotlin/venus/assembler/PseudoWriter.kt
@@ -11,5 +11,5 @@ abstract class PseudoWriter {
      * @param state the assembler's state
      * @return a list of LineTokens corresponding to the TAL instruction
      */
-    internal abstract operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens>
+    internal abstract operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens>
 }

--- a/src/main/kotlin/venus/assembler/pseudos/BEQZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BEQZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `beqz rs, label` */
 object BEQZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("beq", args[1], "x0", args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BGEZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BGEZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `bgez rs, label` */
 object BGEZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("bge", args[1], "x0", args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BGT.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BGT.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `bgt rs, rt, label` */
 object BGT : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         return listOf(listOf("blt", args[2], args[1], args[3]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BGTU.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BGTU.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `bgtu rs, rt, label` */
 object BGTU : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         return listOf(listOf("bltu", args[2], args[1], args[3]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BGTZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BGTZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `bgtz rs, label` */
 object BGTZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("blt", "x0", args[1], args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BLE.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BLE.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `ble rs, rt, label` */
 object BLE : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         return listOf(listOf("bge", args[2], args[1], args[3]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BLEU.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BLEU.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `bleu rs, rt, label` */
 object BLEU : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         return listOf(listOf("bgeu", args[2], args[1], args[3]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BLEZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BLEZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `blez rs, label` */
 object BLEZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("bge", "x0", args[1], args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BLTZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BLTZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `bltz rs, label` */
 object BLTZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("blt", args[1], "x0", args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/BNEZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/BNEZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `bnez rs, label` */
 object BNEZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("bne", args[1], "x0", args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/CALL.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/CALL.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 import venus.riscv.insts.dsl.relocators.PCRelHiRelocator
@@ -10,7 +10,7 @@ import venus.riscv.insts.dsl.relocators.PCRelLoRelocator
  * Writes pseudoinstruction `call label`.
  */
 object CALL : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 2)
 
         val auipc = listOf("auipc", "x6", "0")

--- a/src/main/kotlin/venus/assembler/pseudos/J.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/J.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `j label` */
 object J : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 2)
         return listOf(listOf("jal", "x0", args[1]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/JAL.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/JAL.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `jal label` */
 object JAL : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 2)
         return listOf(listOf("jal", "x1", args[1]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/JALR.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/JALR.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `jalr reg` */
 object JALR : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 2)
         return listOf(listOf("jalr", "x1", args[1], "0"))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/JR.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/JR.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `jr register` */
 object JR : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 2)
         return listOf(listOf("jalr", "x0", args[1], "0"))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/LA.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/LA.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 import venus.riscv.insts.dsl.relocators.PCRelHiRelocator
@@ -12,7 +12,7 @@ import venus.riscv.insts.dsl.relocators.PCRelLoRelocator
  * Uses a `auipc` / `addi` pair and adds them to the relocation table
  */
 object LA : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
 
         val auipc = listOf("auipc", args[1], "0")

--- a/src/main/kotlin/venus/assembler/pseudos/LI.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/LI.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.AssemblerError
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
@@ -12,7 +12,7 @@ import venus.riscv.userStringToInt
  * This either expands to an `addi` if `imm` is small or a `lui` / `addi` pair if `imm` is big.
  */
 object LI : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         val imm = try {
             userStringToInt(args[2])

--- a/src/main/kotlin/venus/assembler/pseudos/Load.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/Load.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 import venus.riscv.insts.dsl.relocators.PCRelHiRelocator
@@ -10,7 +10,7 @@ import venus.riscv.insts.dsl.relocators.PCRelLoRelocator
  * Writes a load pseudoinstruction. (Those applied to a label)
  */
 object Load : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
 
         val auipc = listOf("auipc", args[1], "0")

--- a/src/main/kotlin/venus/assembler/pseudos/MV.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/MV.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `mv rd, rs1` */
 object MV : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("addi", args[1], args[2], "0"))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/NEG.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/NEG.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `neg rd, rs` */
 object NEG : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("sub", args[1], "x0", args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/NOP.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/NOP.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `nop` */
 object NOP : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 1)
         return listOf(listOf("addi", "x0", "x0", "0"))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/NOT.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/NOT.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `not rd, rs` */
 object NOT : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("xori", args[1], args[2], "-1"))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/RET.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/RET.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `ret` */
 object RET : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 1)
         return listOf(listOf("jalr", "x0", "x1", "0"))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/SEQ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SEQ.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
@@ -9,7 +9,7 @@ import venus.assembler.PseudoWriter
  * @todo add a settings option for "extended pseudoinstructions"
  */
 object SEQ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         checkStrictMode()
         val subtract = listOf("sub", args[1], args[2], args[3])

--- a/src/main/kotlin/venus/assembler/pseudos/SEQZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SEQZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `seqz rd, rs` */
 object SEQZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("sltiu", args[1], args[2], "1"))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/SGE.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SGE.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
@@ -9,7 +9,7 @@ import venus.assembler.PseudoWriter
  * @todo add a settings option for "extended pseudoinstructions"
  */
 object SGE : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         checkStrictMode()
         val unsigned = if (args[0].endsWith("u")) "u" else ""

--- a/src/main/kotlin/venus/assembler/pseudos/SGT.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SGT.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
@@ -9,7 +9,7 @@ import venus.assembler.PseudoWriter
  * @todo add a settings option for "extended pseudoinstructions"
  */
 object SGT : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         checkStrictMode()
         val unsigned = if (args[0].endsWith("u")) "u" else ""

--- a/src/main/kotlin/venus/assembler/pseudos/SGTZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SGTZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `sgtz rd, rs` */
 object SGTZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("slt", args[1], "x0", args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/SLE.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SLE.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
@@ -9,7 +9,7 @@ import venus.assembler.PseudoWriter
  * @todo add a settings option for "extended pseudoinstructions"
  */
 object SLE : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         checkStrictMode()
         val unsigned = if (args[0].endsWith("u")) "u" else ""

--- a/src/main/kotlin/venus/assembler/pseudos/SLTZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SLTZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `sltz rd, rs` */
 object SLTZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("slt", args[1], args[2], "x0"))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/SNE.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SNE.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
@@ -9,7 +9,7 @@ import venus.assembler.PseudoWriter
  * @todo add a settings option for "extended pseudoinstructions"
  */
 object SNE : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         checkStrictMode()
         val subtract = listOf("sub", args[1], args[2], args[3])

--- a/src/main/kotlin/venus/assembler/pseudos/SNEZ.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/SNEZ.kt
@@ -1,12 +1,12 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 
 /** Writes pseudoinstruction `snez rd, rs` */
 object SNEZ : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 3)
         return listOf(listOf("sltu", args[1], "x0", args[2]))
     }

--- a/src/main/kotlin/venus/assembler/pseudos/Store.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/Store.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 import venus.riscv.insts.dsl.relocators.PCRelHiRelocator
@@ -11,7 +11,7 @@ import venus.riscv.userStringToInt
  * Writes a store pseudoinstruction. (Those applied to a label)
  */
 object Store : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 4)
         val label = args[2]
         try {

--- a/src/main/kotlin/venus/assembler/pseudos/TAIL.kt
+++ b/src/main/kotlin/venus/assembler/pseudos/TAIL.kt
@@ -1,6 +1,6 @@
 package venus.assembler.pseudos
 
-import venus.assembler.AssemblerPassOne
+import venus.assembler.AssemblerPassTwo
 import venus.assembler.LineTokens
 import venus.assembler.PseudoWriter
 import venus.riscv.insts.dsl.relocators.PCRelHiRelocator
@@ -10,7 +10,7 @@ import venus.riscv.insts.dsl.relocators.PCRelLoRelocator
  * Writes pseudoinstruction `tail label`.
  */
 object TAIL : PseudoWriter() {
-    override operator fun invoke(args: LineTokens, state: AssemblerPassOne): List<LineTokens> {
+    override operator fun invoke(args: LineTokens, state: AssemblerPassTwo): List<LineTokens> {
         checkArgsLength(args, 2)
 
         val auipc = listOf("auipc", "x6", "0")


### PR DESCRIPTION
# .macro Implementation
This pull request introduces an implementation of RISC-V .macro directives.
Macros can be defined and are expanded before the code is executed.
This functionality is realized using a new assembler pass that runs before the currently existing two passes. That way expanded macros are also treated by the pseudo-op pass and error handling functionality.

### Macro example:
```
.macro clean a
	xor \a \a \a
.endm

.macro load reg val
    clean \reg
	li \reg \val
.endm

load x5 5
```
Gets converted into:
```
xor x5 x5 x5
li x5 5
```
which is later converted into:
```
xor x5 x5 x5
addi x5 x0 5
```